### PR TITLE
Consolidate projects by agency for each PIF

### DIFF
--- a/_plugins/joiner.rb
+++ b/_plugins/joiner.rb
@@ -1,19 +1,42 @@
 module Pif
   class Joiner
     def self.join_data(site)
-      site.data['agencies'] = filter_agencies(site)
+      filter_agencies(site)
+      consolidate_pif_projects_by_agency(site)
     end
 
     def self.filter_agencies(site)
-      projects = site.data['current_projects'].values
-      projects.concat site.data['previous_projects'].values
+      projects = consolidate_all_projects(site)
       agencies = {}
       projects.each do |p|
         agency = (agencies[p['agency']] ||= {})
         (agency['fellows'] ||= []).concat (p['fellows'] || [])
       end
       agencies.each_value {|a| a['fellows'] = a['fellows'].compact.sort.uniq}
-      agencies
+      site.data['agencies'] = agencies
+    end
+
+    def self.consolidate_pif_projects_by_agency(site)
+      site.data['fellows'].each_value {|f| f['projects'] = Hash.new}
+      consolidate_all_projects(site).each do |project|
+        agency = project['agency']
+        (project['fellows'] || []).each do |fellow_name|
+          next if fellow_name == nil
+          fellow = site.data['fellows'][fellow_name]
+          projects = fellow['projects']
+          (projects[agency] ||= Array.new) << project['name']
+        end
+      end
+    end
+
+    private
+
+    def self.consolidate_all_projects(site)
+      return site.data['projects'] if site.data['projects'] != nil
+      projects = []
+      projects.concat site.data['current_projects'].values
+      projects.concat site.data['previous_projects'].values
+      site.data['projects'] = projects
     end
   end
 end

--- a/_plugins/joiner.rb
+++ b/_plugins/joiner.rb
@@ -13,7 +13,7 @@ module Pif
         (agency['fellows'] ||= []).concat (p['fellows'] || [])
       end
       agencies.each_value {|a| a['fellows'] = a['fellows'].compact.sort.uniq}
-      site.data['agencies'] = agencies
+      site.data['agencies'] = Hash[agencies.sort_by {|i| i[0].downcase}]
     end
 
     def self.consolidate_pif_projects_by_agency(site)
@@ -26,6 +26,11 @@ module Pif
           projects = fellow['projects']
           (projects[agency] ||= Array.new) << project['name']
         end
+      end
+
+      site.data['fellows'].each_value do |f|
+        f['projects'] = Hash[f['projects'].sort_by {|i| i[0].downcase}]
+        f['projects'].each_value {|v| v.sort_by! {|i| i.downcase}}
       end
     end
 

--- a/_test/joiner_consolidate_pif_projects_by_agency_test.rb
+++ b/_test/joiner_consolidate_pif_projects_by_agency_test.rb
@@ -68,5 +68,61 @@ module Pif
       assert_equal({'SBA' => ['RFP-EZ']},
         fellows['read-robert']['projects'])
     end
+
+    def test_sort_consolidated_pif_projects
+
+      # We'll lie and say Mollie worked on NASA and SBA projects to test the
+      # sort order of 'projects' keys.
+      @site.data['current_projects'] = {
+        'Blue Button Initiative' => {
+          'name' => 'Blue Button Initiative',
+          'agency' => 'VA',
+          'fellows' => ['ruskin-mollie'],
+        },
+        'RFP-EZ' => {
+          'name' => 'RFP-EZ',
+          'agency' => 'SBA',
+          'fellows' => ['ruskin-mollie'],
+        },
+        'Veteran Employment Center' => {
+          'name' => 'Veteran Employment Center',
+          'agency' => 'VA',
+          'fellows' => ['ruskin-mollie'],
+        },
+      }
+      @site.data['previous_projects'] = {
+        'Human Centered Design' => {
+           'name' => 'Human Centered Design',
+           'agency' => 'VA',
+           'fellows' => ['ruskin-mollie'],
+        },
+        'api.nasa.gov' => {
+          'name' => 'api.nasa.gov',
+          'agency' => 'NASA',
+          'fellows' => ['ruskin-mollie'],
+         },
+        'va.gov/data' => {
+           'name' => 'va.gov/data',
+           'agency' => 'VA',
+           'fellows' => ['ruskin-mollie'],
+        },
+      }
+
+      Joiner.consolidate_pif_projects_by_agency(@site)
+      fellows = @site.data['fellows']
+      projects = fellows['ruskin-mollie']['projects']
+      assert_equal(
+        {'VA' => [
+          'Blue Button Initiative',
+          'Human Centered Design',
+          'va.gov/data',
+          'Veteran Employment Center',
+          ],
+         'SBA' => ['RFP-EZ'],
+         'NASA' => ['api.nasa.gov'],
+        },
+        projects)
+      assert_equal ['NASA', 'SBA', 'VA'], projects.keys
+    end
   end
 end

--- a/_test/joiner_consolidate_pif_projects_by_agency_test.rb
+++ b/_test/joiner_consolidate_pif_projects_by_agency_test.rb
@@ -1,0 +1,72 @@
+require_relative "../_plugins/joiner"
+require_relative "site"
+
+require "minitest/autorun"
+
+module Pif
+  class ConsolidatePifProjectsByAgencyTest < ::Minitest::Test
+    def setup
+      @site = DummyTestSite.new
+      @site.data['current_projects'] = {}
+      @site.data['previous_projects'] = {}
+      @site.data['fellows'] = {
+        'hammer-dan' => {},
+        'black-tom' => {},
+        'ruskin-mollie' => {},
+        'godbout-greg' => {},
+        'read-robert' => {},
+      }
+    end
+
+    def test_empty_projects
+      Joiner.consolidate_pif_projects_by_agency(@site)
+      fellows = @site.data['fellows']
+      assert_empty fellows['hammer-dan']['projects']
+      assert_empty fellows['black-tom']['projects']
+      assert_empty fellows['ruskin-mollie']['projects']
+      assert_empty fellows['godbout-greg']['projects']
+      assert_empty fellows['read-robert']['projects']
+    end
+
+    def test_consolidate_pif_projects
+      @site.data['current_projects'] = {
+        'api.nasa.gov' => {
+          'name' => 'api.nasa.gov',
+          'agency' => 'NASA',
+          'fellows' => ['hammer-dan'],
+         },
+        'Blue Button Initiative' => {
+          'name' => 'Blue Button Initiative',
+          'agency' => 'VA',
+          'fellows' => ['black-tom', 'ruskin-mollie'],
+         },
+      }
+      @site.data['previous_projects'] = {
+        'Human Centered Design' => {
+          'name' => 'Human Centered Design',
+          'agency' => 'VA',
+          'fellows' => ['ruskin-mollie'],
+        },
+        'RFP-EZ' => {
+          'name' => 'RFP-EZ',
+          'agency' => 'SBA',
+          'fellows' => ['read-robert', 'godbout-greg'],
+        },
+      }
+
+      Joiner.consolidate_pif_projects_by_agency(@site)
+      fellows = @site.data['fellows']
+      assert_equal({'NASA' => ['api.nasa.gov']},
+        fellows['hammer-dan']['projects'])
+      assert_equal({'VA' => ['Blue Button Initiative']},
+        fellows['black-tom']['projects'])
+      assert_equal(
+        {'VA' => ['Blue Button Initiative', 'Human Centered Design']},
+        fellows['ruskin-mollie']['projects'])
+      assert_equal({'SBA' => ['RFP-EZ']},
+        fellows['godbout-greg']['projects'])
+      assert_equal({'SBA' => ['RFP-EZ']},
+        fellows['read-robert']['projects'])
+    end
+  end
+end

--- a/_test/joiner_filter_agencies_test.rb
+++ b/_test/joiner_filter_agencies_test.rb
@@ -45,6 +45,7 @@ module Pif
         'SBA' => {'fellows' => ['godbout-greg', 'read-robert']},
       }
       assert_equal expected,  @site.data['agencies']
+      assert_equal ['NASA', 'SBA', 'VA'], @site.data['agencies'].keys
     end
   end
 end

--- a/_test/joiner_filter_agencies_test.rb
+++ b/_test/joiner_filter_agencies_test.rb
@@ -12,7 +12,7 @@ module Pif
     end
 
     def test_empty_projects
-      Joiner.join_data(@site)
+      Joiner.filter_agencies(@site)
       assert_empty @site.data['agencies']
     end
 
@@ -37,7 +37,7 @@ module Pif
           'fellows' => ['read-robert', 'godbout-greg'],
         },
       }
-      Joiner.join_data(@site)
+      Joiner.filter_agencies(@site)
 
       expected = {
         'NASA' => {'fellows' => ['hammer-dan']},


### PR DESCRIPTION
Closes #4. For each PIF, there's now a 'projects' member that is a hash from
{agency short name => [list of project names]}.

After this, I'll send a PR to sort the agency names.

cc: @stroupaloop @FreeMason