### PR TITLE
Fix gsa.gov link

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -21,9 +21,9 @@
           </div>
           <div class="col-sm-6 hidden-xs">
             <ul>
-              <li><h4><a href="https://whitehouse.gov/innovationfellows" target="_blank">White House</a></h4></li>
-              <li><h4><a href="https://whitehouse.gov/issues" target="_blank">Presidential Priorities</a></h4></li>
-              <li><h4><a href="https://gsa.gov" target="_blank">GSA</a></h4></li>
+              <li><h4><a href="https://www.whitehouse.gov/innovationfellows" target="_blank">White House</a></h4></li>
+              <li><h4><a href="https://www.whitehouse.gov/issues" target="_blank">Presidential Priorities</a></h4></li>
+              <li><h4><a href="http://gsa.gov" target="_blank">GSA</a></h4></li>
               <li><h4><a href="https://18f.gsa.gov" target="_blank">18F</a></h4></li>
               <li><h4><a href="https://www.whitehouse.gov/digital/united-states-digital-service" target="_blank">USDS</a></h4></li>
             </ul>
@@ -52,7 +52,7 @@
         </div>
       </div>
       <div class="col-lg-1 col-lg-offset-5 col-md-1 col-md-offset-4 col-sm-2 col-sm-offset-3 hidden-xs">
-        <a href="https://whitehouse.gov/innovationfellows" target="_blank"><img src="{{ baseurl }}/assets/images/logo-white-house.png" class="img-responsive"></a>
+        <a href="https://www.whitehouse.gov/innovationfellows" target="_blank"><img src="{{ baseurl }}/assets/images/logo-white-house.png" class="img-responsive"></a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Sadly, they still don't support HTTPS, so the `gsa.gov` link fails to work.