### PR TITLE
Tightens up analytics settings

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -70,9 +70,13 @@
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
   m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
   ga('create', 'UA-48605964-25', 'auto');
+
+  ga('set', 'anonymizeIp', true);
+  ga('set', 'forceSSL', true);
+
   ga('send', 'pageview');
 
 </script>


### PR DESCRIPTION
This follows the [18F standard analytics settings](https://github.com/18F/analytics-standards#javascript-code-snippet), which enforce HTTPS (more of a nice-to-have for an already HTTPS site), and turn on [IP address anonymization](https://support.google.com/analytics/answer/2763052?hl=en).